### PR TITLE
fixes issue #6 : enabled scrolling in recycler view

### DIFF
--- a/app/src/main/java/com/theayushyadav11/MessEase/ui/MessCommittee/fragments/PollsFragment.kt
+++ b/app/src/main/java/com/theayushyadav11/MessEase/ui/MessCommittee/fragments/PollsFragment.kt
@@ -75,7 +75,7 @@ class PollsFragment : Fragment() {
             }
 
             override fun canScrollVertically(): Boolean {
-                return false
+                return true
             }
         }
 

--- a/app/src/main/res/layout/fragment_polls.xml
+++ b/app/src/main/res/layout/fragment_polls.xml
@@ -25,7 +25,7 @@
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:nestedScrollingEnabled="false"
+        android:nestedScrollingEnabled="true"
         android:padding="15dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Resolves #6 

Before there were only two or three poles listed in the poll section, now all the created polls are visible.
enabled nested scrolling in recycler view and return true for override scroll vertically.

https://github.com/user-attachments/assets/ecde4e33-6888-4a5a-b906-d8f0697aeb9e

- [x] I have read all the contributor guidelines for the repo.
