### PR TITLE
feat: add per-meal notification toggle

### DIFF
--- a/app/src/main/java/com/theayushyadav11/MessEase/MainActivity.kt
+++ b/app/src/main/java/com/theayushyadav11/MessEase/MainActivity.kt
@@ -375,10 +375,13 @@ class MainActivity : AppCompatActivity() {
             )
 
             for (i in times.indices) {
+                cancelAllAlarms(this, i)
+            }
+
+
+            for (i in times.indices) {
                 if (enabledStates[i]) {
                     scheduleAlarm(i, times[i], intent)
-                } else {
-                    cancelAllAlarms(this, i)
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/theayushyadav11/MessEase/MainActivity.kt
+++ b/app/src/main/java/com/theayushyadav11/MessEase/MainActivity.kt
@@ -367,8 +367,19 @@ class MainActivity : AppCompatActivity() {
             mess.log("Setting alarms: Breakfast ${times[0]}, Lunch ${times[1]}, " +
                     "Snack ${times[2]}, Dinner ${times[3]}")
 
+            val enabledStates = listOf(
+                mess.isMealEnabled("bt_enabled"),
+                mess.isMealEnabled("lt_enabled"),
+                mess.isMealEnabled("st_enabled"),
+                mess.isMealEnabled("dt_enabled")
+            )
+
             for (i in times.indices) {
-                scheduleAlarm(i, times[i], intent)
+                if (enabledStates[i]) {
+                    scheduleAlarm(i, times[i], intent)
+                } else {
+                    cancelAllAlarms(this, i)
+                }
             }
         } catch (e: Exception) {
             mess.log("Error setting alarms: ${e.message}")

--- a/app/src/main/java/com/theayushyadav11/MessEase/ui/more/SettingsActivity.kt
+++ b/app/src/main/java/com/theayushyadav11/MessEase/ui/more/SettingsActivity.kt
@@ -16,6 +16,9 @@ import java.util.Calendar
 class SettingsActivity : AppCompatActivity() {
     private lateinit var binding:ActivitySettingsBinding
     private lateinit var mess:Mess
+
+    private val tempStates = mutableMapOf<String, Boolean>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
 
         super.onCreate(savedInstanceState)
@@ -29,6 +32,10 @@ class SettingsActivity : AppCompatActivity() {
         setupToggle("lt_enabled", binding.switchLunch, binding.timel, binding.pickl)
         setupToggle("st_enabled", binding.switchSnacks, binding.times, binding.picks)
         setupToggle("dt_enabled", binding.switchDinner, binding.timed, binding.pickd)
+        tempStates["bt_enabled"] = mess.isMealEnabled("bt_enabled")
+        tempStates["lt_enabled"] = mess.isMealEnabled("lt_enabled")
+        tempStates["st_enabled"] = mess.isMealEnabled("st_enabled")
+        tempStates["dt_enabled"] = mess.isMealEnabled("dt_enabled")
 
     }
 
@@ -42,7 +49,12 @@ class SettingsActivity : AppCompatActivity() {
 
     fun listeners()
     {
-        val b= mutableListOf("07:30","12:0","16:30","19:0")
+        val b = mutableListOf(
+            mess.get("bt","7:30"),
+            mess.get("lt","12:0"),
+            mess.get("st","16:30"),
+            mess.get("dt","19:0")
+        )
         binding.pickb.setOnClickListener{
             showTimePicker(0, 0, 10, 0) {it,p->
                 binding.timeb.text = it
@@ -75,8 +87,13 @@ class SettingsActivity : AppCompatActivity() {
             mess.save("st",b[2])
             mess.save("dt",b[3])
             mess.log(b)
-            mess.toast("Timings Updated")
             //cancelAllAlarms(this@SettingsActivity)
+            mess.setMealEnabled("bt_enabled", tempStates["bt_enabled"]!!)
+            mess.setMealEnabled("lt_enabled", tempStates["lt_enabled"]!!)
+            mess.setMealEnabled("st_enabled", tempStates["st_enabled"]!!)
+            mess.setMealEnabled("dt_enabled", tempStates["dt_enabled"]!!)
+
+            mess.toast("Settings Updated")
             finish()
         }
 
@@ -151,7 +168,7 @@ class SettingsActivity : AppCompatActivity() {
         updateUIState(isEnabled, timeView, picker)
 
         switch.setOnCheckedChangeListener { _, checked ->
-            mess.setMealEnabled(key, checked)
+            tempStates[key] = checked
             updateUIState(checked, timeView, picker)
         }
     }

--- a/app/src/main/java/com/theayushyadav11/MessEase/ui/more/SettingsActivity.kt
+++ b/app/src/main/java/com/theayushyadav11/MessEase/ui/more/SettingsActivity.kt
@@ -3,7 +3,10 @@ package com.theayushyadav11.MessEase.ui.more
 import android.app.TimePickerDialog
 import android.graphics.Color
 import android.os.Bundle
+import android.widget.Switch
+import android.widget.TextView
 import android.widget.Toast
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.theayushyadav11.MessEase.databinding.ActivitySettingsBinding
@@ -14,6 +17,7 @@ class SettingsActivity : AppCompatActivity() {
     private lateinit var binding:ActivitySettingsBinding
     private lateinit var mess:Mess
     override fun onCreate(savedInstanceState: Bundle?) {
+
         super.onCreate(savedInstanceState)
        binding= ActivitySettingsBinding.inflate(layoutInflater)
         setContentView(binding.root)
@@ -21,6 +25,10 @@ class SettingsActivity : AppCompatActivity() {
         setUpToolBar()
         initialise()
         listeners()
+        setupToggle("bt_enabled", binding.switchBreakfast, binding.timeb, binding.pickb)
+        setupToggle("lt_enabled", binding.switchLunch, binding.timel, binding.pickl)
+        setupToggle("st_enabled", binding.switchSnacks, binding.times, binding.picks)
+        setupToggle("dt_enabled", binding.switchDinner, binding.timed, binding.pickd)
 
     }
 
@@ -131,4 +139,32 @@ class SettingsActivity : AppCompatActivity() {
         val formattedTime = timeFormat.format(selectedTime.time)
         return formattedTime
     }
+    private fun setupToggle(
+        key: String,
+        switch: Switch,
+        timeView: TextView,
+        picker: View
+    ) {
+        val isEnabled = mess.isMealEnabled(key)
+        switch.isChecked = isEnabled
+
+        updateUIState(isEnabled, timeView, picker)
+
+        switch.setOnCheckedChangeListener { _, checked ->
+            mess.setMealEnabled(key, checked)
+            updateUIState(checked, timeView, picker)
+        }
+    }
+
+    private fun updateUIState(
+        isEnabled: Boolean,
+        timeView: TextView,
+        picker: View
+    ) {
+        timeView.alpha = if (isEnabled) 1f else 0.4f
+        picker.isEnabled = isEnabled
+    }
+
+
+
 }

--- a/app/src/main/java/com/theayushyadav11/MessEase/ui/more/SettingsActivity.kt
+++ b/app/src/main/java/com/theayushyadav11/MessEase/ui/more/SettingsActivity.kt
@@ -162,6 +162,7 @@ class SettingsActivity : AppCompatActivity() {
         picker: View
     ) {
         timeView.alpha = if (isEnabled) 1f else 0.4f
+        picker.alpha = if (isEnabled) 1f else 0.4f
         picker.isEnabled = isEnabled
     }
 

--- a/app/src/main/java/com/theayushyadav11/MessEase/utils/Mess.kt
+++ b/app/src/main/java/com/theayushyadav11/MessEase/utils/Mess.kt
@@ -587,6 +587,14 @@ class Mess(context: Context) {
        return get("isSkipped","false").toBoolean()
     }
 
+    fun setMealEnabled(key: String, value: Boolean) {
+        sharedPreferences.edit().putBoolean(key, value).apply()
+    }
+
+    fun isMealEnabled(key: String): Boolean {
+        return sharedPreferences.getBoolean(key, true)
+    }
+
 }
 
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -75,6 +75,14 @@
                         android:textStyle="bold"
                         app:layout_constraintStart_toEndOf="@id/v"
                         app:layout_constraintTop_toTopOf="parent" />
+                    <Switch
+                        android:id="@+id/switchBreakfast"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintEnd_toStartOf="@id/pickb"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        android:layout_marginEnd="8dp"/>
 
                     <TextView
                         android:id="@+id/timeb"
@@ -137,6 +145,14 @@
                         android:textStyle="bold"
                         app:layout_constraintStart_toEndOf="@id/v2"
                         app:layout_constraintTop_toTopOf="parent" />
+                    <Switch
+                        android:id="@+id/switchLunch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintEnd_toStartOf="@id/pickl"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        android:layout_marginEnd="8dp"/>
 
                     <TextView
                         android:id="@+id/timel"
@@ -201,6 +217,14 @@
                         android:textStyle="bold"
                         app:layout_constraintStart_toEndOf="@id/v3"
                         app:layout_constraintTop_toTopOf="parent" />
+                    <Switch
+                        android:id="@+id/switchSnacks"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintEnd_toStartOf="@id/picks"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        android:layout_marginEnd="8dp"/>
 
                     <TextView
                         android:id="@+id/times"
@@ -267,6 +291,14 @@
                         android:textStyle="bold"
                         app:layout_constraintStart_toEndOf="@id/v5"
                         app:layout_constraintTop_toTopOf="parent" />
+                    <Switch
+                        android:id="@+id/switchDinner"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintEnd_toStartOf="@id/pickd"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        android:layout_marginEnd="8dp"/>
 
                     <TextView
                         android:id="@+id/timed"


### PR DESCRIPTION
Resolves #5

## Description

This PR adds the ability to enable/disable notifications for individual meals (Breakfast, Lunch, Snacks, Dinner) from the Settings screen.

Previously, users could only modify the timing of meal reminders, but could not disable them entirely. This resulted in unnecessary notifications even when users were not interested in specific meals.

###  Key Changes
- Added toggle switches for each meal in `SettingsActivity`
- Stored toggle state using `SharedPreferences` via `Mess.kt`
- Updated alarm scheduling logic in `MainActivity` to:
  - Schedule alarms only for enabled meals
  - Cancel alarms when a meal is disabled
- Improved UI to reflect disabled state:
  - Reduced opacity of time and the alarm icon for disabled meals
  - Disabled interaction for time picker when toggle is OFF

###  Behavior
- If a meal is disabled → its alarm is not scheduled
- If re-enabled → alarm is scheduled again
- Preferences persist across app restarts

---

## Live Demo


https://github.com/user-attachments/assets/9507405e-423f-41ff-9cf8-762de36326a2




### Before
- All meal notifications were always scheduled

![WhatsApp Image 2026-04-11 at 04 09 21](https://github.com/user-attachments/assets/2d74936f-5baa-4d18-a66f-9b4337b4aa90)


### After
- Users can toggle notifications per meal
- Disabled meals appear faded and non-interactive

<img width="720" height="1608" alt="image" src="https://github.com/user-attachments/assets/1717e778-9622-42c2-90d3-b78e2c35f074" />



---

## Checkout
- [x] I have read all the contributor guidelines for the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added toggles in Settings to enable/disable individual meals (breakfast, lunch, snacks, dinner).
  * App now persists meal enablement across sessions.

* **Behavior Changes**
  * Alarms are only scheduled for meals that are enabled; alarms for disabled meals are cancelled.

* **UI**
  * Settings shows enabled/disabled state and greys out time pickers when a meal is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->