### PR TITLE
Fix/safe binding admin fragment

### DIFF
--- a/app/src/main/java/com/theayushyadav11/MessEase/ui/NavigationDrawers/Fragments/AdminFragment.kt
+++ b/app/src/main/java/com/theayushyadav11/MessEase/ui/NavigationDrawers/Fragments/AdminFragment.kt
@@ -69,21 +69,21 @@ class AdminFragment : Fragment() {
     }
 
     private fun add(email: String, designation: String) {
-        // Disable button to avoid spam clicking
-        binding.btnAdd.isEnabled = false
-        binding.btnAdd.text = "Adding..."
+        _binding?.let { binding ->
+            binding.btnAdd.isEnabled = false
+            binding.btnAdd.text = "Adding..."
+        }
 
         mess.addPb("Adding to Mess Committee")
 
-        viewModel.addToMessCommittee(email, designation) {
+        viewModel.addToMessCommittee(email, designation) { result ->
+            val binding = _binding ?: return@addToMessCommittee
             mess.pbDismiss()
 
             binding.btnAdd.isEnabled = true
             binding.btnAdd.text = "Add to Committee"
 
-            mess.toast(it)
-
-            // Clear fields after success
+            mess.toast(result)
             binding.etEmail.text?.clear()
             binding.spinnerAutoComplete.text?.clear()
         }

--- a/app/src/main/java/com/theayushyadav11/MessEase/ui/NavigationDrawers/Fragments/AdminFragment.kt
+++ b/app/src/main/java/com/theayushyadav11/MessEase/ui/NavigationDrawers/Fragments/AdminFragment.kt
@@ -13,28 +13,23 @@ import com.theayushyadav11.MessEase.utils.Constants.Companion.DESIGNATION
 import com.theayushyadav11.MessEase.utils.Mess
 
 class AdminFragment : Fragment() {
-    private lateinit var binding: FragmentAdminBinding
-    private lateinit var mess: Mess
 
+    private var _binding: FragmentAdminBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var mess: Mess
     private val viewModel: AdminViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
-        binding = FragmentAdminBinding.inflate(layoutInflater, container, false)
+        _binding = FragmentAdminBinding.inflate(inflater, container, false)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
         initialise()
         listeners()
-    }
-
-    private fun listeners() {
-        binding.btnAdd.setOnClickListener {
-            add()
-        }
     }
 
     private fun initialise() {
@@ -42,31 +37,71 @@ class AdminFragment : Fragment() {
         setAdapter()
     }
 
+    private fun listeners() {
+        binding.btnAdd.setOnClickListener {
+            validateAndAdd()
+        }
+    }
 
-    fun add() {
-        if (binding.etEmail.text.toString().isNotEmpty()) {
-            mess.addPb("Adding to Mess Committee")
-            viewModel.addToMessCommittee(
-                binding.etEmail.text.toString(),
-                binding.spinnerAutoComplete.text.toString()
-            )
-            {
-                mess.pbDismiss()
-                mess.toast(it)
+    private fun validateAndAdd() {
+        val email = binding.etEmail.text.toString().trim()
+        val designation = binding.spinnerAutoComplete.text.toString().trim()
+
+        when {
+            email.isEmpty() -> {
+                binding.tilEmail.error = "Email required"
             }
-        } else {
-            mess.toast("Please enter email")
+
+            !android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches() -> {
+                binding.tilEmail.error = "Invalid email"
+            }
+
+            designation.isEmpty() -> {
+                binding.tilspin.error = "Select designation"
+            }
+
+            else -> {
+                binding.tilEmail.error = null
+                binding.tilspin.error = null
+                add(email, designation)
+            }
+        }
+    }
+
+    private fun add(email: String, designation: String) {
+        // Disable button to avoid spam clicking
+        binding.btnAdd.isEnabled = false
+        binding.btnAdd.text = "Adding..."
+
+        mess.addPb("Adding to Mess Committee")
+
+        viewModel.addToMessCommittee(email, designation) {
+            mess.pbDismiss()
+
+            binding.btnAdd.isEnabled = true
+            binding.btnAdd.text = "Add to Committee"
+
+            mess.toast(it)
+
+            // Clear fields after success
+            binding.etEmail.text?.clear()
+            binding.spinnerAutoComplete.text?.clear()
         }
     }
 
     private fun setAdapter() {
         mess.getLists("${DESIGNATION}s") {
-            val spinner = binding.spinnerAutoComplete
-            val spinnerItems = it
-            val adapter =
-                ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, spinnerItems)
-            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-            spinner.setAdapter(adapter)
+            val adapter = ArrayAdapter(
+                requireContext(),
+                android.R.layout.simple_dropdown_item_1line,
+                it
+            )
+            binding.spinnerAutoComplete.setAdapter(adapter)
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/res/drawable/baseline_attach_email_24.xml
+++ b/app/src/main/res/drawable/baseline_attach_email_24.xml
@@ -1,7 +1,8 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:width="24dp"
     android:height="24dp"
-    android:tint="#A19C9C"
+    android:tint="@color/food"
     android:viewportWidth="24"
     android:viewportHeight="24">
 
@@ -11,6 +12,7 @@
 
     <path
         android:fillColor="@android:color/white"
+        app:tint="@color/food"
         android:pathData="M21,14v4c0,1.1 -0.9,2 -2,2s-2,-0.9 -2,-2v-4.5c0,-0.28 0.22,-0.5 0.5,-0.5s0.5,0.22 0.5,0.5V18h2v-4.5c0,-1.38 -1.12,-2.5 -2.5,-2.5S15,12.12 15,13.5V18c0,2.21 1.79,4 4,4s4,-1.79 4,-4v-4H21z" />
 
 </vector>

--- a/app/src/main/res/drawable/baseline_person_24.xml
+++ b/app/src/main/res/drawable/baseline_person_24.xml
@@ -1,7 +1,7 @@
     <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="#A19C9C"
+    android:tint="@color/food"
     android:viewportWidth="24"
     android:viewportHeight="24">
 

--- a/app/src/main/res/drawable/bg_card_glass_inner.xml
+++ b/app/src/main/res/drawable/bg_card_glass_inner.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:startColor="#FFFFFF"
+        android:endColor="#F5F5F5"
+        android:angle="270"/>
+    <corners android:radius="22dp"/>
+</shape>

--- a/app/src/main/res/drawable/bg_gradient_full.xml
+++ b/app/src/main/res/drawable/bg_gradient_full.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape>
+    <gradient xmlns:android="http://schemas.android.com/apk/res/android"
+        android:startColor="#FF6F00"
+        android:endColor="#FFB74D"
+        android:angle="270"/>
+</shape>

--- a/app/src/main/res/drawable/bg_icon_soft.xml
+++ b/app/src/main/res/drawable/bg_icon_soft.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- res/drawable/bg_icon_soft.xml -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#22FFFFFF"/>
+    <corners android:radius="50dp"/>
+</shape>

--- a/app/src/main/res/layout/fragment_admin.xml
+++ b/app/src/main/res/layout/fragment_admin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/bg">
@@ -9,19 +9,17 @@
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:scrollbars="none"
         android:fillViewport="true"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:scrollbars="none"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingBottom="32dp">
+            android:paddingBottom="40dp">
 
-            <!-- Header with icon -->
+            <!-- HEADER ICON -->
             <ImageView
                 android:id="@+id/ivHeaderIcon"
                 android:layout_width="60dp"
@@ -29,11 +27,13 @@
                 android:layout_marginStart="25dp"
                 android:layout_marginTop="32dp"
                 android:src="@drawable/logo"
-                android:contentDescription="Mess committee icon"
+                app:tint="@color/food"
+                android:background="@drawable/bg_icon_soft"
+                android:padding="14dp"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:tint="@color/food" />
+                app:layout_constraintTop_toTopOf="parent"/>
 
+            <!-- TITLE -->
             <TextView
                 android:id="@+id/textView"
                 android:layout_width="0dp"
@@ -42,47 +42,63 @@
                 android:layout_marginEnd="25dp"
                 android:text="Add to Mess Committee"
                 android:textColor="@color/food"
-                android:textSize="28sp"
+                android:textSize="26sp"
                 android:textStyle="bold"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/ivHeaderIcon"
-                app:layout_constraintTop_toTopOf="@+id/ivHeaderIcon"
-                app:layout_constraintBottom_toBottomOf="@+id/ivHeaderIcon" />
+                app:layout_constraintStart_toEndOf="@id/ivHeaderIcon"
+                app:layout_constraintTop_toTopOf="@id/ivHeaderIcon"
+                app:layout_constraintEnd_toEndOf="parent"/>
 
-            <!-- Divider -->
+            <!-- SUBTITLE -->
+            <TextView
+                android:id="@+id/subtitle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="Manage committee members easily"
+                android:textColor="@color/food"
+                android:textSize="14sp"
+                android:alpha="0.7"
+                app:layout_constraintStart_toStartOf="@id/textView"
+                app:layout_constraintTop_toBottomOf="@id/textView"
+                app:layout_constraintEnd_toEndOf="parent"/>
+
+            <!-- DIVIDER -->
             <View
                 android:id="@+id/divider"
                 android:layout_width="0dp"
                 android:layout_height="2dp"
                 android:layout_marginHorizontal="25dp"
-                android:layout_marginTop="24dp"
+                android:layout_marginTop="20dp"
                 android:background="@color/food"
                 android:alpha="0.2"
-                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/ivHeaderIcon"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/textView" />
+                app:layout_constraintEnd_toEndOf="parent"/>
 
-            <!-- Card container -->
+            <!-- MAIN CARD -->
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/cardView"
                 android:layout_width="0dp"
-                app:cardBackgroundColor="@color/bg"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="25dp"
-                android:layout_marginTop="32dp"
-                app:cardCornerRadius="12dp"
-                app:cardElevation="4dp"
-                app:layout_constraintEnd_toEndOf="parent"
+                android:layout_marginTop="30dp"
+
+                android:backgroundTint="#CCFFFFFF"
+                app:strokeColor="#40FFFFFF"
+                app:cardCornerRadius="22dp"
+                app:cardElevation="12dp"
+                app:strokeWidth="1dp"
+
+                app:layout_constraintTop_toBottomOf="@id/divider"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/divider"
-                app:strokeColor="@color/food"
-                app:strokeWidth="1dp">
+                app:layout_constraintEnd_toEndOf="parent">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="20dp">
+                    android:background="@drawable/bg_card_glass_inner"
+                    android:padding="22dp">
 
+                    <!-- FORM TITLE -->
                     <TextView
                         android:id="@+id/tvFormTitle"
                         android:layout_width="wrap_content"
@@ -92,82 +108,123 @@
                         android:textSize="18sp"
                         android:textStyle="bold"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
+                        app:layout_constraintTop_toTopOf="parent"/>
 
+                    <!-- EMAIL -->
                     <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/tilEmail"
                         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                        app:boxStrokeWidth="1.5dp"
+
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="24dp"
+
                         android:hint="Email Address"
+
                         app:boxStrokeColor="@color/food"
-                        app:boxStrokeWidth="2dp"
+                        app:boxStrokeWidthFocused="3dp"
+
+                        app:boxCornerRadiusTopStart="18dp"
+                        app:boxCornerRadiusTopEnd="18dp"
+                        app:boxCornerRadiusBottomStart="18dp"
+                        app:boxCornerRadiusBottomEnd="18dp"
+
                         app:endIconMode="clear_text"
-                        app:endIconTint="@color/food"
-                        app:helperTextTextColor="#FF0015"
-                        app:hintTextColor="@color/food"
-                        app:layout_constraintEnd_toEndOf="parent"
+
+                        app:layout_constraintTop_toBottomOf="@id/tvFormTitle"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@+id/tvFormTitle"
-                        app:startIconDrawable="@drawable/baseline_attach_email_24"
-                        app:startIconTint="@color/food">
+                        app:layout_constraintEnd_toEndOf="parent">
 
                         <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/etEmail"
                             android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:inputType="textEmailAddress" />
+                            android:layout_height="56dp"
+
+                            android:drawableStart="@drawable/baseline_attach_email_24"
+                            android:drawablePadding="12dp"
+
+                            android:paddingStart="12dp"
+                            android:paddingEnd="12dp"
+
+                            android:textColor="@color/black"
+                            android:textColorHint="#80AAAAAA"
+                            android:inputType="textEmailAddress"/>
+
                     </com.google.android.material.textfield.TextInputLayout>
 
+                    <!-- DESIGNATION -->
                     <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/tilspin"
                         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-                        android:layout_width="match_parent"
+
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="24dp"
+                        android:layout_marginTop="20dp"
+
                         android:hint="Designation"
+
                         app:boxStrokeColor="@color/food"
-                        app:boxStrokeWidth="2dp"
-                        app:endIconTint="@color/food"
-                        app:helperTextTextColor="@color/food"
-                        app:hintTextColor="@color/food"
-                        app:layout_constraintEnd_toEndOf="parent"
+                        app:boxStrokeWidthFocused="3dp"
+
+                        app:boxCornerRadiusTopStart="18dp"
+                        app:boxCornerRadiusTopEnd="18dp"
+                        app:boxCornerRadiusBottomStart="18dp"
+                        app:boxCornerRadiusBottomEnd="18dp"
+
+
+                        app:endIconMode="dropdown_menu"
+
+                        app:layout_constraintTop_toBottomOf="@id/tilEmail"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@+id/tilEmail"
-                        app:startIconDrawable="@drawable/baseline_person_24"
-                        app:startIconTint="@color/food">
+                        app:boxStrokeWidth="1.5dp"
+                        app:layout_constraintEnd_toEndOf="parent">
 
                         <AutoCompleteTextView
-                            android:textColor="@color/black"
                             android:id="@+id/spinnerAutoComplete"
                             android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:inputType="none" />
+                            android:layout_height="56dp"
+
+                            android:drawableStart="@drawable/baseline_person_24"
+                            android:drawablePadding="12dp"
+
+                            android:paddingStart="12dp"
+                            android:paddingEnd="12dp"
+
+                            android:textColor="@color/black"
+                            android:textColorHint="#80AAAAAA"
+                            android:inputType="none"/>
 
                     </com.google.android.material.textfield.TextInputLayout>
+
                 </androidx.constraintlayout.widget.ConstraintLayout>
+
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- BUTTON -->
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnAdd"
+                android:letterSpacing="0.03"
                 android:layout_width="0dp"
                 android:layout_height="60dp"
                 android:layout_marginHorizontal="25dp"
                 android:layout_marginTop="40dp"
-                android:backgroundTint="@color/food"
+
                 android:text="Add to Committee"
                 android:textColor="@color/white"
                 android:textSize="16sp"
-                app:cornerRadius="5dp"
-                app:elevation="4dp"
 
+                app:cornerRadius="20dp"
+                app:elevation="10dp"
+
+                app:icon="@drawable/baseline_person_24"
                 app:iconGravity="textStart"
-                app:iconPadding="8dp"
+                app:iconPadding="10dp"
                 app:iconTint="@color/white"
-                app:layout_constraintEnd_toEndOf="parent"
+
+                app:layout_constraintTop_toBottomOf="@id/cardView"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/cardView" />
+                app:layout_constraintEnd_toEndOf="parent"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/app/src/main/res/layout/fragment_admin.xml
+++ b/app/src/main/res/layout/fragment_admin.xml
@@ -80,7 +80,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="25dp"
-                android:layout_marginTop="30dp"
+                android:layout_marginTop="50dp"
 
                 android:backgroundTint="#CCFFFFFF"
                 app:strokeColor="#40FFFFFF"
@@ -94,6 +94,7 @@
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
+
                     android:layout_height="wrap_content"
                     android:background="@drawable/bg_card_glass_inner"
                     android:padding="22dp">
@@ -108,33 +109,33 @@
                         android:textSize="18sp"
                         android:textStyle="bold"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"/>
+                        app:layout_constraintTop_toTopOf="parent" />
 
                     <!-- EMAIL -->
                     <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/tilEmail"
                         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                        app:boxStrokeWidth="1.5dp"
-
                         android:layout_width="0dp"
+
                         android:layout_height="wrap_content"
                         android:layout_marginTop="24dp"
-
                         android:hint="Email Address"
 
-                        app:boxStrokeColor="@color/food"
-                        app:boxStrokeWidthFocused="3dp"
+                        app:boxCornerRadiusBottomEnd="18dp"
+
+                        app:boxCornerRadiusBottomStart="18dp"
+                        app:boxCornerRadiusTopEnd="18dp"
 
                         app:boxCornerRadiusTopStart="18dp"
-                        app:boxCornerRadiusTopEnd="18dp"
-                        app:boxCornerRadiusBottomStart="18dp"
-                        app:boxCornerRadiusBottomEnd="18dp"
+                        app:boxStrokeColor="@color/food"
+                        app:boxStrokeWidth="1.5dp"
+                        app:boxStrokeWidthFocused="3dp"
 
                         app:endIconMode="clear_text"
 
-                        app:layout_constraintTop_toBottomOf="@id/tvFormTitle"
+                        app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent">
+                        app:layout_constraintTop_toBottomOf="@id/tvFormTitle">
 
                         <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/etEmail"
@@ -144,12 +145,12 @@
                             android:drawableStart="@drawable/baseline_attach_email_24"
                             android:drawablePadding="12dp"
 
+                            android:inputType="textEmailAddress"
                             android:paddingStart="12dp"
-                            android:paddingEnd="12dp"
 
+                            android:paddingEnd="12dp"
                             android:textColor="@color/black"
-                            android:textColorHint="#80AAAAAA"
-                            android:inputType="textEmailAddress"/>
+                            android:textColorHint="#80AAAAAA" />
 
                     </com.google.android.material.textfield.TextInputLayout>
 
@@ -164,21 +165,21 @@
 
                         android:hint="Designation"
 
+                        app:boxCornerRadiusBottomEnd="18dp"
+                        app:boxCornerRadiusBottomStart="18dp"
+
+                        app:boxCornerRadiusTopEnd="18dp"
+                        app:boxCornerRadiusTopStart="18dp"
                         app:boxStrokeColor="@color/food"
+                        app:boxStrokeWidth="1.5dp"
+
+
                         app:boxStrokeWidthFocused="3dp"
 
-                        app:boxCornerRadiusTopStart="18dp"
-                        app:boxCornerRadiusTopEnd="18dp"
-                        app:boxCornerRadiusBottomStart="18dp"
-                        app:boxCornerRadiusBottomEnd="18dp"
-
-
                         app:endIconMode="dropdown_menu"
-
-                        app:layout_constraintTop_toBottomOf="@id/tilEmail"
+                        app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:boxStrokeWidth="1.5dp"
-                        app:layout_constraintEnd_toEndOf="parent">
+                        app:layout_constraintTop_toBottomOf="@id/tilEmail">
 
                         <AutoCompleteTextView
                             android:id="@+id/spinnerAutoComplete"
@@ -188,12 +189,12 @@
                             android:drawableStart="@drawable/baseline_person_24"
                             android:drawablePadding="12dp"
 
+                            android:inputType="none"
                             android:paddingStart="12dp"
-                            android:paddingEnd="12dp"
 
+                            android:paddingEnd="12dp"
                             android:textColor="@color/black"
-                            android:textColorHint="#80AAAAAA"
-                            android:inputType="none"/>
+                            android:textColorHint="#80AAAAAA" />
 
                     </com.google.android.material.textfield.TextInputLayout>
 
@@ -204,11 +205,11 @@
             <!-- BUTTON -->
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnAdd"
-                android:letterSpacing="0.03"
                 android:layout_width="0dp"
                 android:layout_height="60dp"
                 android:layout_marginHorizontal="25dp"
-                android:layout_marginTop="40dp"
+                android:layout_marginTop="80dp"
+                android:letterSpacing="0.03"
 
                 android:text="Add to Committee"
                 android:textColor="@color/white"
@@ -222,9 +223,9 @@
                 app:iconPadding="10dp"
                 app:iconTint="@color/white"
 
-                app:layout_constraintTop_toBottomOf="@id/cardView"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"/>
+                app:layout_constraintTop_toBottomOf="@id/cardView" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>


### PR DESCRIPTION
Resolves #49 

## Description

This PR fixes a crash in `AdminFragment`.

Earlier, the async callback was using `binding` directly.  
If the user left the screen before the callback finished, the view was destroyed and the app crashed with a NullPointerException.

Now, `_binding` is checked safely before using it inside the callback.  
If the view is already destroyed, the callback just exits and does nothing.

This makes the app more stable and prevents crashes during navigation.

## Checklist
- [x] I have read all the contributor guidelines for the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced email validation for committee member addition with proper pattern matching
  * Added designation field validation requirement
  * Progress indication during committee member submission

* **Style**
  * Updated admin interface with gradient backgrounds and improved card design
  * Enhanced form field appearance with refined styling
  * Improved button design with better visual hierarchy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->